### PR TITLE
Compatibility improvements

### DIFF
--- a/lib/classes/battery.dart
+++ b/lib/classes/battery.dart
@@ -10,12 +10,16 @@ class Battery {
       batteryPresent:               'POWER_SUPPLY_PRESENT',               // 1/0, whether battery is present
       batteryTechnology:            'POWER_SUPPLY_TECHNOLOGY',            // Li-poly
       batteryCycleCount:            'POWER_SUPPLY_CYCLE_COUNT',           // 99
-      batteryVoltageMinDesign:      'POWER_SUPPLY_VOLTAGE_MIN_DESIGN',    // 11400000
-      batteryVoltageNow:            'POWER_SUPPLY_VOLTAGE_NOW',           // 11049000
-      batteryCurrentNow:            'POWER_SUPPLY_CURRENT_NOW',           // 1675000
-      batteryChargeFullDesign:      'POWER_SUPPLY_CHARGE_FULL_DESIGN',    // 7393000
-      batteryChargeFull:            'POWER_SUPPLY_CHARGE_FULL',           // 6439000
-      batteryChargeNow:             'POWER_SUPPLY_CHARGE_NOW',            // 2119000
+      batteryVoltageMinDesign:      'POWER_SUPPLY_VOLTAGE_MIN_DESIGN',    // mV - 11400000
+      batteryVoltageNow:            'POWER_SUPPLY_VOLTAGE_NOW',           // mV - 11049000
+      batteryCurrentNow:            'POWER_SUPPLY_CURRENT_NOW',           // mA - 1675000
+      batteryPowerNow:              'POWER_SUPPLY_POWER_NOW',             // mW
+      batteryChargeFullDesign:      'POWER_SUPPLY_CHARGE_FULL_DESIGN',    // mAh - 7393000
+      batteryChargeFull:            'POWER_SUPPLY_CHARGE_FULL',           // mAh - 6439000
+      batteryChargeNow:             'POWER_SUPPLY_CHARGE_NOW',            // mAh - 2119000
+      batteryEnergyFullDesign:      'POWER_SUPPLY_ENERGY_FULL_DESIGN',    // mWh
+      batteryEnergyFull:            'POWER_SUPPLY_ENERGY_FULL',           // mWh
+      batteryEnergyNow:             'POWER_SUPPLY_ENERGY_NOW',            // mWh
       batteryCapacity:              'POWER_SUPPLY_CAPACITY',              // 32
       batteryCapacityLevel:         'POWER_SUPPLY_CAPACITY_LEVEL',        // Normal
       batteryModelName:             'POWER_SUPPLY_MODEL_NAME',            // DELL 70N2F34
@@ -32,13 +36,13 @@ class Battery {
       batteryCharging:              'Charging',                           // True/False
       batteryDischarging:           'Discharging',                        // True/False
       batteryChargeRate:            'ChargeRate',
-      batteryDischargeRate:         'DischargeRate',                      // 15618
-      batteryVoltageNow:            'Voltage',                            // 11448 (@50%) - live voltage, NOT design voltage
+      batteryDischargeRate:         'DischargeRate',                      // mW - 15618
+      batteryVoltageNow:            'Voltage',                            // mV - 11448 (@50%) - live voltage, NOT design voltage
       batteryCycleCount:            'CycleCount',                         // 99
       batteryCapacityLevel:         'Critical',                           // True/False
-      batteryCapacityFullDesign:    'DesignedCapacity',                   // Wh - 84280
-      batteryCapacityFull:          'FullChargedCapacity',                // Wh - 72743
-      batteryCapacityNow:           'RemainingCapacity',                  // Wh - 42248
+      batteryCapacityFullDesign:    'DesignedCapacity',                   // mWh - 84280
+      batteryCapacityFull:          'FullChargedCapacity',                // mWh - 72743
+      batteryCapacityNow:           'RemainingCapacity',                  // mWh - 42248
       batteryModelName:             'DeviceName',                         // DELL 70N2F34
       batteryManufacturer:          'ManufactureName',                    // SMP
       batterySerialNumber:          'SerialNumber',                       // 625

--- a/lib/classes/battery_state.dart
+++ b/lib/classes/battery_state.dart
@@ -8,13 +8,13 @@ class BatteryState {
   String?   batteryType;
   String?   batteryTechnology;
   int?      batteryCycleCount;
-  double?   batteryVoltageMinDesign;
-  double?   batteryVoltageNow;
-  double?   batteryCurrentNow;
-  double?   batteryChargeFullDesign;
-  double?   batteryChargeFull;
-  double?   batteryChargeNow;
-  int?      batteryPercentage;
+  double?   batteryVoltageMinDesign;    // V
+  double?   batteryVoltageNow;          // V
+  double?   batteryCurrentNow;          // A
+  double?   batteryChargeFullDesign;    // Ah
+  double?   batteryChargeFull;          // Ah
+  double?   batteryChargeNow;           // Ah
+  int?      batteryPercentage;          // %
   bool?     batteryPercentageLow;
   String?   batteryModelName;
   String?   batteryManufacturer;
@@ -46,6 +46,11 @@ class BatteryState {
     batteryHealth           = _setIfPresent(map[Battery.batteryInfoLinux.args.batteryChargeFull],       (var x) => double.parse(x) / double.parse(map[Battery.batteryInfoLinux.args.batteryChargeFullDesign]) * 100);
     batteryDesignCapacity   = _setIfPresent(map[Battery.batteryInfoLinux.args.batteryChargeFullDesign], (var x) => double.parse(x) / 1000000 * double.parse(map[Battery.batteryInfoLinux.args.batteryVoltageMinDesign]) / 1000000);
     batteryCurrentPower     = _setIfPresent(map[Battery.batteryInfoLinux.args.batteryCurrentNow],       (var x) => double.parse(x) / 1000000 * double.parse(map[Battery.batteryInfoLinux.args.batteryVoltageNow]) / 1000000);
+
+    // Some battery types use different parameters, if previous methods failed, attempt to use alt parameters
+    batteryHealth         ??= _setIfPresent(map[Battery.batteryInfoLinux.args.batteryEnergyFull],       (var x) => double.parse(x) / double.parse(map[Battery.batteryInfoLinux.args.batteryEnergyFullDesign]) * 100);
+    batteryDesignCapacity ??= _setIfPresent(map[Battery.batteryInfoLinux.args.batteryEnergyFullDesign], (var x) => double.parse(x) / 1000000);
+    batteryCurrentPower   ??= _setIfPresent(map[Battery.batteryInfoLinux.args.batteryPowerNow], (var x) => double.parse(x) / 1000000);
   }
   BatteryState.fromWindowsMap(Map<String, dynamic> map) {
     powerSupplyPresent      = _setIfPresent(map[Battery.batteryInfoWindows.args.powerSupplyPresent],    (var x) => x == "True");

--- a/lib/classes/sudoers_manager.dart
+++ b/lib/classes/sudoers_manager.dart
@@ -13,8 +13,8 @@ class SudoersManager {
     ProcessResult pr;
     if (Platform.isLinux) {
       // (Linux) Verify that cctk bin was added to sudoers
-      pr = (await _shell.run('''bash -c "export PATH="${Constants.apiPathLinux}:\$PATH" && [[ \$(sudo -n \$(which cctk) 2>/dev/null) != '' ]]"'''))[0];
-      runningSudo = pr.exitCode == 0;
+      pr = (await _shell.run('''bash -c "export PATH="${Constants.apiPathLinux}:\$PATH" && sudo -n \$(which cctk) 2>/dev/null"'''))[0];
+      runningSudo = pr.exitCode != 1;
     } else {
       // (Windows) Verify that app is running as admin
       pr = (await _shell.run('''cmd /c cmd /c "${Constants.apiPathWindows}"'''))[0];


### PR DESCRIPTION
* [x] (Linux) Some devices have apparently have different set of POWER_SUPPLY.... parameters, which shall be parsed instead. Also document unit for all used parameters
* [x] (linux) CCTK behaves weirdly on non-dell machines: no useful output, only empty new line and status 0 (linux) for any requests. Sudo is still required. ~~Handle this and show different warning message~~. Fix missing sudo permission detection