### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dell machines (XPS and Precision series laptops, potentially others) offer advan
 * [Dell Command | Configure](https://www.dell.com/support/kbdoc/en-us/000178000/dell-command-configure) CLI, available for both Windows and Linux, with impressive [list of capabilities](https://dl.dell.com/topicspdf/command-configure_reference-guide4_en-us.pdf).
 * [Dell Power Manager](https://www.dell.com/support/contents/en-au/article/product-support/self-support-knowledgebase/software-and-downloads/dell-power-manager) GUI, available for Windows only. On top of that, it is ridiculously slow to start, and (subjectively) ugly.
 
-This app is a modern, Flutter based GUI on top of Dell Command | Configure CLI, with main goal to replicate behavior of Dell Power Manager for Linux users. If it proves to be useful, I may add support for Windows as well.
+This app is a modern, Flutter based GUI on top of Dell Command | Configure CLI, with main goal to replicate behavior of Dell Power Manager for Linux users, but also does run on Windows.
 
 ## Features
 * Implement control via 'Dell Command | Configure CLI', installed separately or via integrated installer
@@ -44,7 +44,7 @@ Application is currently in __public beta__ stage.
 * UI tested, build and packaging asserted by CI
 * Dell's CCTK integrated, as well as automated installer
 * Tested on multiple platforms, see [Compatibility](#compatibility)
-* Packaged to `.deb`/`.msi`, get latest stable build at [Releases](https://github.com/alexVinarskis/dell-powermanager/releases/latest), or latest development build at [CI artifacts](https://github.com/alexVinarskis/dell-powermanager/actions/workflows/build.yml?query=branch%3Amaster)
+* Packaged to `.msi`, `.deb`, `.tar.xz`. Get latest stable build at [Releases](https://github.com/alexVinarskis/dell-powermanager/releases/latest), or latest development build at [CI artifacts](https://github.com/alexVinarskis/dell-powermanager/actions/workflows/build.yml?query=branch%3Amaster)
 * OTA integrated via Github API
 
 ### Linux
@@ -54,6 +54,11 @@ Application is currently in __public beta__ stage.
 ### Windows
 * Run from source via `flutter run`, build via `flutter build windows --release`
 * Package to `.msi` via `.\package.bat`
+
+## Debugging
+
+By default, all logging is supressed. Export `POWERMANAGER_DEBUG=true` before running app from CLI to get logs.
+When opening an issue, kindly save and attach the log.
 
 ## Compatibility
 Tested on the following devices:

--- a/lib/classes/api_battery.dart
+++ b/lib/classes/api_battery.dart
@@ -4,6 +4,7 @@ import 'package:process_run/shell.dart';
 
 import '../classes/battery_state.dart';
 import '../classes/battery.dart';
+import '../configs/environment.dart';
 
 class ApiBattery {
   static final List<Duration> _additionalRefreshInternals = [];
@@ -29,7 +30,7 @@ class ApiBattery {
   static late Duration _initialRefreshInternal;
   static late Duration _refreshInternal;
   static late Timer _timer;
-  static final _shell = Shell(throwOnError: false);
+  static final _shell = Shell(verbose: Environment.runningDebug, throwOnError: false);
 
   static BatteryState? batteryState;
 

--- a/lib/classes/api_cctk.dart
+++ b/lib/classes/api_cctk.dart
@@ -8,6 +8,7 @@ import '../configs/constants.dart';
 import '../classes/dependencies_manager.dart';
 import '../classes/cctk_state.dart';
 import '../classes/cctk.dart';
+import '../configs/environment.dart';
 
 class ApiCCTK {
   static final List _initialQueryParameters = [CCTK.thermalManagement, CCTK.primaryBattChargeCfg];
@@ -34,7 +35,7 @@ class ApiCCTK {
   static late Timer _timer;
   static bool? _apiReady;
   static bool _cctkMutexLocked = false;
-  static final _shell = Shell(throwOnError: false);
+  static final _shell = Shell(verbose: Environment.runningDebug, throwOnError: false);
 
   static SharedPreferences? _prefs;
 

--- a/lib/classes/api_powermode.dart
+++ b/lib/classes/api_powermode.dart
@@ -4,6 +4,7 @@ import 'package:process_run/shell.dart';
 
 import '../classes/powermode_state.dart';
 import '../classes/powermode.dart';
+import '../configs/environment.dart';
 
 class ApiPowermode {
   static final List<Duration> _additionalRefreshInternals = [];
@@ -29,7 +30,7 @@ class ApiPowermode {
   static late Duration _initialRefreshInternal;
   static late Duration _refreshInternal;
   static late Timer _timer;
-  static final _shell = Shell(throwOnError: false, runInShell: true);
+  static final _shell = Shell(verbose: Environment.runningDebug, throwOnError: false, runInShell: true);
 
   static PowermodeState? powermodeState;
   static bool powermodeSupported = true;

--- a/lib/classes/dependencies_manager.dart
+++ b/lib/classes/dependencies_manager.dart
@@ -3,9 +3,10 @@ import 'dart:io';
 import 'package:process_run/shell.dart';
 
 import '../configs/constants.dart';
+import '../configs/environment.dart';
 
 class DependenciesManager {
-  static final _shell = Shell(throwOnError: false);
+  static final _shell = Shell(verbose: Environment.runningDebug, throwOnError: false);
   static bool? supportsAutoinstall;
 
   static Future<void> verifySupportsAutoinstall() async {

--- a/lib/classes/ota_manager.dart
+++ b/lib/classes/ota_manager.dart
@@ -6,9 +6,10 @@ import 'package:process_run/shell.dart';
 import 'package:version/version.dart';
 
 import '../configs/constants.dart';
+import '../configs/environment.dart';
 
 class OtaManager {
-  static final _shell = Shell(throwOnError: false);
+  static final _shell = Shell(verbose: Environment.runningDebug, throwOnError: false);
 
   // [tagname, releaseUrl, downloadUrl]
   static Future<List<String>> checkLatestOta() async {

--- a/lib/classes/sudoers_manager.dart
+++ b/lib/classes/sudoers_manager.dart
@@ -3,9 +3,10 @@ import 'dart:io';
 import 'package:process_run/shell.dart';
 
 import '../configs/constants.dart';
+import '../configs/environment.dart';
 
 class SudoersManager {
-  static final _shell = Shell(throwOnError: false);
+  static final _shell = Shell(verbose: Environment.runningDebug, throwOnError: false);
   static const sudoersPatchCmd = 'export PATH="${Constants.apiPathLinux}:\$PATH" && echo "ALL ALL=(ALL) NOPASSWD: \$(which cctk)" | sudo tee /etc/sudoers.d/${Constants.applicationPackageName}';
   static bool? runningSudo;
 

--- a/lib/configs/constants.dart
+++ b/lib/configs/constants.dart
@@ -1,5 +1,6 @@
 class Constants {
   static const animationMs = 250;
+  static const animationFastMs = 150;
 
   static const authorName = 'alexVinarskis';
   static const applicationLegalese = '\u{a9} 2023 ${Constants.authorName}';
@@ -27,7 +28,7 @@ class Constants {
   static const apiPathLinux = '/opt/dell/dcc';
   static const applicationName = 'Dell Power Manager by VA';
   static const applicationPackageName = 'dell-powermanager';
-  static const applicationVersion = '0.8.0-22-gd544023+20231230-130025';
+  static const applicationVersion = '0.1.0';
 
   static const githubApiReleases = '${Constants.urlApi}/releases/latest';
   static const githubApiRequest = 'curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28"';

--- a/lib/configs/environment.dart
+++ b/lib/configs/environment.dart
@@ -1,0 +1,3 @@
+class Environment {
+  static bool runningDebug = false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:dell_powermanager/classes/api_powermode.dart';
+import 'package:dell_powermanager/configs/environment.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -34,6 +35,13 @@ Future<void> main() async {
     final license = await rootBundle.loadString('assets/fonts/OFL.txt');
     yield LicenseEntryWithLineBreaks(['assets/fonts'], license);
   });
+
+  if (kDebugMode) {
+    Environment.runningDebug = true;
+  }
+  if (Platform.environment["POWERMANAGER_DEBUG"]?.toLowerCase() == 'true') {
+    Environment.runningDebug = true;
+  }
 
   ApiCCTK(const Duration(milliseconds: 10000));
   ApiBattery(const Duration(milliseconds: 10000));

--- a/lib/screens/screen_parent.dart
+++ b/lib/screens/screen_parent.dart
@@ -34,9 +34,9 @@ class ScreenParentState extends State<ScreenParent> {
 
   Widget _getRHSScreen(MenuItems menuMode) {
     switch (menuMode) {
-      case MenuItems.battery: return const ScreenBattery(key: Key("screenBattery"));
-      case MenuItems.thermals: return const ScreenThermals(key: Key("screenThermals"));
-      default: return ScreenSummary(key: const Key("screenSummary"), menuCallback: _handleMenuCallback,);
+      case MenuItems.battery: return const ScreenBattery();
+      case MenuItems.thermals: return const ScreenThermals();
+      default: return ScreenSummary(menuCallback: _handleMenuCallback,);
     }
   }
 
@@ -122,8 +122,11 @@ class ScreenParentState extends State<ScreenParent> {
                     color: Theme.of(context).colorScheme.background,
                   ),
                   child: AnimatedSwitcher(
-                    duration: const Duration(milliseconds: Constants.animationMs),
-                    child: Column(children: [_getRHSScreen(currentMenu)]),
+                    duration: const Duration(milliseconds: Constants.animationFastMs),
+                    child: Column(
+                      key: Key("$currentMenu"),
+                      children: [_getRHSScreen(currentMenu)],
+                    ),
                   ),
                 ),
               ),

--- a/lib/screens/screen_thermals.dart
+++ b/lib/screens/screen_thermals.dart
@@ -8,6 +8,7 @@ import '../classes/powermode.dart';
 import '../components/mode_item.dart';
 import '../classes/cctk.dart';
 import '../classes/cctk_state.dart';
+import '../configs/constants.dart';
 
 const indexTitle = 0;
 const indexDescription = 1;
@@ -85,22 +86,28 @@ class ScreenThermalsState extends State<ScreenThermals> {
   }
 
   Widget _getPowermodeBadge(BuildContext context, {double paddingH = 0, double paddingV = 0,}) {
-    return Card(
-      clipBehavior: Clip.antiAlias,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(25.0),
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: Constants.animationMs),
+      child: ApiPowermode.powermodeSupported ? Card(
+        key: const Key("powermodeSupported"),
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(25.0),
+        ),
+        color: Colors.amber.withOpacity(0.4),
+        elevation: 0,
+        margin: EdgeInsets.symmetric(vertical: paddingV, horizontal: paddingH),
+        child: _powermodeState == null ?
+          SkeletonAnimation(
+            curve: Curves.easeInOutCirc,
+            shimmerColor: Theme.of(context).colorScheme.secondaryContainer,
+            gradientColor: Theme.of(context).colorScheme.secondaryContainer.withOpacity(0),
+            child: _getPowermodeContent(context),
+          ) :
+          _getPowermodeContent(context),
+      ) : const SizedBox(
+        key: Key("powermodeUnsupported"),
       ),
-      color: Colors.amber.withOpacity(0.4),
-      elevation: 0,
-      margin: EdgeInsets.symmetric(vertical: paddingV, horizontal: paddingH),
-      child: _powermodeState == null ?
-        SkeletonAnimation(
-          curve: Curves.easeInOutCirc,
-          shimmerColor: Theme.of(context).colorScheme.secondaryContainer,
-          gradientColor: Theme.of(context).colorScheme.secondaryContainer.withOpacity(0),
-          child: _getPowermodeContent(context),
-        ) :
-        _getPowermodeContent(context),
     );
   }
   Widget _getPowermodeContent(BuildContext context) {


### PR DESCRIPTION
* [Linux] Detect missing `powerprofilesctl`, stop attempts to read and hide power mode badge
* Fix home screen not animating when switching menus
* Disable all logging by default. Enable when running Flutter debug build, or `POWERMANAGER_DEBUG=true` was exported to env vars.