### PR TITLE
chore: update libssl1.1 url, for good now

### DIFF
--- a/lib/configs/constants.dart
+++ b/lib/configs/constants.dart
@@ -15,7 +15,7 @@ class Constants {
 
   // [link, filename]
   static const packagesLinuxUrlDell = ['https://dl.dell.com/FOLDER09518608M/1/command-configure_4.10.0-5.ubuntu22_amd64.tar.gz', 'command-configure_4.10.0-5.ubuntu22_amd64.tar.gz'];
-  static const packagesLinuxUrlLibssl = ['http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb', 'libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb'];
+  static const packagesLinuxUrlLibssl = ['http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb', 'libssl1.1_1.1.1f-1ubuntu2_amd64.deb'];
   static const packagesLinuxDownloadPath = '/tmp/dell-powermanager';
 
   static const packagesWindowsUrlDell = ['https://dl.dell.com/FOLDER09477091M/2/Dell-Command-Configure-Application_D6VXJ_WIN_4.10.0.607_A00_01.EXE', 'Dell-Command-Configure-Application_D6VXJ_WIN_4.10.0.607_A00_01.EXE'];


### PR DESCRIPTION
Fixes https://github.com/alexVinarskis/dell-powermanager/issues/33
I made a mistake of specifying revision of the package, which updates over time, and thus becomes unavailable.