### PR TITLE
ci: linux: improve arm64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,11 @@ jobs:
           path: '*.msi'
           if-no-files-found: error
 
-  build-linux-amd64:
-    runs-on: ubuntu-24.04
+  build-linux:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,47 +52,11 @@ jobs:
           filter: 'tree:0'
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          channel: 'master'
+          flutter-version: 3.29.0
       - run: |
           sudo apt-get update -y
           sudo apt-get install -y ninja-build libgtk-3-dev libsqlite3-dev libsecret-1-0 libsecret-1-dev
-      - run: flutter config --enable-linux-desktop
-      - run: |
-          ./package.sh
-          echo "DEB_FILE=$(ls *.deb)" >> $GITHUB_ENV
-          echo "TAR_FILE=$(ls *.tar.xz)" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.DEB_FILE }}
-          path: '*.deb'
-          if-no-files-found: error
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.TAR_FILE }}
-          path: '*.tar*'
-          if-no-files-found: error
-
-  build-linux-arm64:
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          filter: 'tree:0'
-      - run: |
-          sudo apt-get update -y
-          sudo apt-get install -y curl git unzip xz-utils zip libglu1-mesa clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
-          sudo apt-get install -y libsqlite3-dev libsecret-1-0 libsecret-1-dev
-
-      # Until Google provides ready tarred Flutter SDK for ARM64, we need to clone and install Flutter manually
-      # https://github.com/subosito/flutter-action/issues/345#issuecomment-2638225681
-      - name: Workaround - Clone Flutter
-        run: |
-          git clone --depth 1 --branch stable https://github.com/flutter/flutter.git $RUNNER_TEMP/flutter
-          echo "$RUNNER_TEMP/flutter/bin" >> $GITHUB_PATH
-      - name: Workaround - Install Flutter
-        run: flutter doctor
-
       - run: flutter config --enable-linux-desktop
       - run: |
           ./package.sh


### PR DESCRIPTION
Drop manual clonning workaround, as flutter-action can work on arm64 as well if master channel with
explicit version declartion also works [1].

[1] https://github.com/subosito/flutter-action/issues/345#issuecomment-2657332687